### PR TITLE
Clarify tie-breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,18 @@ False
 >>> print(str(vca1))
 {"A":1}
 
-# these two clocks are not ordered, but we tie-break by default
+# these two clocks are not ordered
 >>> vcb = VectorClock({"B": 1})
 >>> print(vca1 == vcb)
 False
 >>> print(vca1 < vcb)
-True
->>> print(vca1.compare(vcb))
--1
+False
 # If tie-breaking is off, they are not ordered (but not equal!)
 >>> print(vca1.compare(vcb, tiebreak=False))
 0
+# If tie-breaking is on, we pick an order (deterministically)
+>>> print(vca1.compare(vcb, tiebreak=True))
+-1
 ```
 
 The rest of this README is for vectorclock developers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "vectorclock"
 authors = [{ name = "boxydog"}]
 description = "A vector clock"
 # also change version in setup.cfg
-version = "0.5.2"
+version = "0.5.3"
 license = {text = "MIT License"}
 readme = "README.md"
 keywords = ["vector clock"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = vectorclock
 # also change version in pyproject.toml
-version = 0.5.2
+version = 0.5.3
 
 [options]
 packages = find:

--- a/tests/test_vectorclock.py
+++ b/tests/test_vectorclock.py
@@ -8,11 +8,11 @@ class TestVectorClock(unittest.TestCase):
         vca1 = VectorClock({"A": 1})
         # self-comparison
         self.assertEqual(vca1, vca1)
-        self.assertEqual(0, vca1.compare(vca1))
+        self.assertEqual(0, vca1.compare(vca1, True))
         self.assertFalse(vca1 > vca1)
-        self.assertTrue(vca1 >= vca1)
+        # self.assertTrue(vca1 >= vca1)
         self.assertFalse(vca1 < vca1)
-        self.assertTrue(vca1 <= vca1)
+        # self.assertTrue(vca1 <= vca1)
 
         # None comparison
         with self.assertRaises(AttributeError):
@@ -22,48 +22,50 @@ class TestVectorClock(unittest.TestCase):
         vca2 = VectorClock({"A": 2})
         self.assertNotEqual(vca1, vca2)
         self.assertLess(vca1, vca2)
-        self.assertLessEqual(vca1, vca2)
+        # self.assertLessEqual(vca1, vca2)
         self.assertGreater(vca2, vca1)
-        self.assertGreaterEqual(vca2, vca1)
+        # self.assertGreaterEqual(vca2, vca1)
 
         # different processes with tied max clock
         # these are unordered but, we tie-break deterministically by default
         vcb = VectorClock({"B": 1})
         self.assertFalse(vca1 == vcb)
         self.assertFalse(vca1 > vcb)
-        self.assertFalse(vca1 >= vcb)
+        # self.assertFalse(vca1 >= vcb)
         self.assertTrue(vca1 != vcb)
-        self.assertTrue(vca1 < vcb)
-        self.assertTrue(vca1 <= vcb)
+        self.assertFalse(vca1 < vcb)
+        # self.assertTrue(vca1 <= vcb)
 
         # If we tie-break (default), these are ordered, and compare returns -1
-        self.assertEqual(-1, vca1.compare(vcb))
+        self.assertEqual(-1, vca1.compare(vcb, True))
         # If we don't tie-break, these are unordered, and compare returns 0
-        self.assertEqual(0, vca1.compare(vcb, tiebreak=False))
+        self.assertEqual(0, vca1.compare(vcb, False))
 
         # different processes with different max clock
-        # pick the higher max
+        # tiebreaking picks the higher max
         vcb2 = VectorClock({"B": 2})
         self.assertFalse(vca1 == vcb2)
         self.assertTrue(vca1 != vcb2)
-        self.assertTrue(vca1 < vcb2)
-        self.assertTrue(vca1 <= vcb2)
+        self.assertFalse(vca1 < vcb2)
+        # self.assertTrue(vca1 <= vcb2)
         self.assertFalse(vca1 > vcb2)
-        self.assertFalse(vca1 >= vcb2)
+        # self.assertFalse(vca1 >= vcb2)
+        self.assertEqual(-1, vca1.compare(vcb2, True))
 
     def test_compare_add_element(self):
         # adding an element makes rev go up
         vcc = VectorClock({"client": 44})
         vcs = VectorClock({"client": 44, "server": 38})
-        self.assertEqual(-1, vcc.compare(vcs))
+        self.assertEqual(-1, vcc.compare(vcs, True))
 
         # TODO: random cases testing that adding an element makes rev go up
 
-    def test_compare_indeterminate(self):
-        # adding an element makes rev go up
+    def test_compare_unordered(self):
+        """These elements are unordered."""
         vc1 = VectorClock({"client": 1, "server": 2})
         vc2 = VectorClock({"client": 2, "server": 1})
-        self.assertEqual(-1, vc1.compare(vc2))
+        self.assertEqual(0, vc1.compare(vc2, False))
+        self.assertEqual(-1, vc1.compare(vc2, True))
 
     def test_setgetclock(self):
         vca1 = VectorClock({})
@@ -93,9 +95,9 @@ class TestVectorClock(unittest.TestCase):
         self.assertFalse(ve == va)
         self.assertTrue(ve != va)
         self.assertTrue(ve < va)
-        self.assertTrue(ve <= va)
+        # self.assertTrue(ve <= va)
         self.assertFalse(ve > va)
-        self.assertFalse(ve >= va)
+        # self.assertFalse(ve >= va)
 
     def test_str(self):
         vc = VectorClock({"A": 1, "B": 3, "a": 10})

--- a/vectorclock/vectorclock.py
+++ b/vectorclock/vectorclock.py
@@ -36,7 +36,7 @@ class VectorClock:
     def get_clock(self, clock: str, default: Optional[int] = None) -> int:
         return self.clocks.get(clock, default)
 
-    def compare(self, other: "VectorClock", tiebreak=True) -> Union[int, None]:
+    def compare(self, other: "VectorClock", tiebreak: bool) -> Union[int, None]:
         """Compare two clocks.
 
         :param other:  Vector clock to compare to.
@@ -116,23 +116,28 @@ class VectorClock:
             return 1
         return 0
 
+    # Equality is ambiguous: does it mean "the same" or simply "unordered"?
+    # We are going to implement it to mean "the same".
+    # So, unordered is not <, >, or ==.
+    # We will implement == and !=, but not <= or >=, as that is confusing.
+
     def __eq__(self, other: "VectorClock") -> bool:
-        return self.compare(other) == 0
+        return self.compare(other, True) == 0
 
     def __ne__(self, other: "VectorClock") -> bool:
-        return self.compare(other) != 0
+        return self.compare(other, True) != 0
 
     def __lt__(self, other: "VectorClock") -> bool:
-        return self.compare(other) < 0
+        return self.compare(other, False) < 0
 
-    def __le__(self, other: "VectorClock") -> bool:
-        return self.compare(other) != 1
+    # def __le__(self, other: "VectorClock") -> bool:
+    #     return self.compare(other) != 1
 
     def __gt__(self, other: "VectorClock") -> bool:
-        return self.compare(other) > 0
+        return self.compare(other, False) > 0
 
-    def __ge__(self, other: "VectorClock") -> bool:
-        return self.compare(other) != -1
+    # def __ge__(self, other: "VectorClock") -> bool:
+    #     return self.compare(other) != -1
 
     def __str__(self) -> str:
         return json.dumps(


### PR DESCRIPTION
- Make ordering operators not use tiebreaking (i.e. typical definition of a vector clock)
- remove <= and >= as confusing
- force declaring tiebreaking in compare
